### PR TITLE
fix a gtk warning

### DIFF
--- a/Menda-Square/index.theme.kde
+++ b/Menda-Square/index.theme.kde
@@ -325,3 +325,10 @@ Type=Fixed
 #Size=16
 #Context=Status
 #Type=Scalable
+
+[categories/scalable]
+Size=16
+MinSize=16
+MaxSize=256
+Context=Categories
+Type=Scalable


### PR DESCRIPTION
Gtk-WARNING **: Theme directory categories/scalable of theme Menda-Square has no size field
